### PR TITLE
Bugfix for missing sponsors

### DIFF
--- a/_includes/theme.css
+++ b/_includes/theme.css
@@ -502,7 +502,6 @@ span.icon {
 }
 .sponsors-block img {
 	width: 100%;
-	max-height: 100%;
 	align-self: center;
 }
 


### PR DESCRIPTION
Fixes missing sponsors (css bug)
You can see that unchecking max-height fixes this bug.

<img width="957" alt="Screen Shot 2019-12-11 at 1 02 04 PM" src="https://user-images.githubusercontent.com/11672661/70651465-7e2da400-1c16-11ea-97a2-59edabf3e49f.png">
<img width="956" alt="Screen Shot 2019-12-11 at 1 01 57 PM" src="https://user-images.githubusercontent.com/11672661/70651466-7e2da400-1c16-11ea-9bb1-a2b7d7408ea6.png">
